### PR TITLE
Update CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,7 @@ jobs:
       - *terraform_init
       - run:
           name: terraform plan
-          command: |
-            terraform plan -out=github.tfplan
+          command: terraform plan -out=github.tfplan
       - persist_to_workspace:
           root: *working_directory
           paths:
@@ -78,15 +77,9 @@ workflows:
     jobs:
       - lint
       - plan
-      - approve:
-          type: approval
-          requires:
-            - plan
-          filters:
-            branches:
-              only: master
       - apply-with-approval:
           requires:
+            - lint
             - approve
           filters:
             branches:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,0 @@
-rules:
-  default:
-    protection:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_status_checks:
-        contexts: []


### PR DESCRIPTION
Updates the CircleCI workflow to remove the approval step. It is not
required anymore as merging the change to master will be consider as the
approval.

Disables mergify for this repository as we cannot accept PRs from forks.